### PR TITLE
cmake: now using external project for edge impulse compiling

### DIFF
--- a/lib/edge_impulse/CMakeLists.ei.template
+++ b/lib/edge_impulse/CMakeLists.ei.template
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.13.1)
+set(CMAKE_C_COMPILER_FORCED   1)
+set(CMAKE_CXX_COMPILER_FORCED 1)
+
+project(edge_impulse)
+enable_language(ASM C CXX)
+
+if(EI_COMPILE_DEFINITIONS)
+  add_compile_definitions(${EI_INTERFACE_COMPILE_DEFINITIONS})
+endif()
+
+if(EI_INCLUDE_DIRECTORIES)
+  include_directories(${EI_INTERFACE_INCLUDE_DIRECTORIES})
+endif()
+
+if(EI_SYSTEM_INCLUDE_DIRECTORIES)
+  include_directories(SYSTEM ${EI_INTERFACE_SYSTEM_INCLUDE_DIRECTORIES})
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../compile_options.CXX.cmake OPTIONAL)
+include(${CMAKE_CURRENT_LIST_DIR}/../../compile_options.C.cmake OPTIONAL)
+
+set(EI_COMPILE_OPTIONS ${EI_C_COMPILE_OPTIONS})
+list(REMOVE_ITEM EI_C_COMPILE_OPTIONS ${EI_CXX_COMPILE_OPTIONS} "")
+list(REMOVE_ITEM EI_COMPILE_OPTIONS ${EI_C_COMPILE_OPTIONS})
+list(REMOVE_ITEM EI_CXX_COMPILE_OPTIONS ${EI_COMPILE_OPTIONS} "")
+
+add_compile_options(${EI_COMPILE_OPTIONS})
+foreach(option ${EI_C_COMPILE_OPTIONS})
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:${option}>)
+endforeach()
+
+foreach(option ${EI_CXX_COMPILE_OPTIONS})
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${option}>)
+endforeach()
+
+if(NOT TARGET app)
+  add_library(app STATIC)
+endif()
+
+if(EI_LIBRARY_NAME)
+  set_property(TARGET app PROPERTY OUTPUT_NAME ${EI_LIBRARY_NAME})
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/edge-impulse-sdk/cmake/utils.cmake)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/edge-impulse-sdk/cmake/zephyr)
+
+target_include_directories(app PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tflite-model
+    ${CMAKE_CURRENT_LIST_DIR}/model-parameters
+)
+
+# find model source files
+RECURSIVE_FIND_FILE(MODEL_FILES "${CMAKE_CURRENT_LIST_DIR}/tflite-model" "*.cpp")
+list(APPEND SOURCE_FILES ${MODEL_FILES})
+
+# add all sources to the project
+target_sources(app PRIVATE ${SOURCE_FILES})

--- a/lib/edge_impulse/CMakeLists.txt
+++ b/lib/edge_impulse/CMakeLists.txt
@@ -4,93 +4,79 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.13)
 
-# Set subdirectory in build dir
-set(EI_BASE_DIR ${CMAKE_BINARY_DIR}/ei)
-set(EI_UNZIPPED_DIR ${EI_BASE_DIR}/unpacked)
-set(EI_BINARY_DIR ${EI_BASE_DIR}/bin)
+set(EDGE_IMPULSE_DIR        ${CMAKE_BINARY_DIR}/edge_impulse)
+set(EDGE_IMPULSE_SOURCE_DIR ${EDGE_IMPULSE_DIR}/src/edge_impulse_project)
+set(EDGE_IMPULSE_BINARY_DIR ${EDGE_IMPULSE_DIR}/src/edge_impulse_project-build)
+set(EDGE_IMPULSE_STAMP_DIR  ${EDGE_IMPULSE_DIR}/src/edge_impulse_project-stamp)
+set(EDGE_IMPULSE_LIBRARY    ${EDGE_IMPULSE_BINARY_DIR}/libedge_impulse.a)
 
-if(NOT EXISTS ${EI_BASE_DIR})
-  file(MAKE_DIRECTORY ${EI_BASE_DIR})
+file(GENERATE OUTPUT ${EDGE_IMPULSE_DIR}/compile_options.$<COMPILE_LANGUAGE>.cmake CONTENT
+"set(EI_$<COMPILE_LANGUAGE>_COMPILE_OPTIONS \"$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>\")"
+)
+
+include(ExternalProject)
+ExternalProject_Add(edge_impulse_project
+    URL              ${CONFIG_EDGE_IMPULSE_DOWNLOAD_URI}
+    HTTP_HEADER      "Accept: application/zip"
+                     ${EI_API_KEY_HEADER}
+    PREFIX           ${EDGE_IMPULSE_DIR}
+    SOURCE_DIR       ${EDGE_IMPULSE_SOURCE_DIR}
+    BINARY_DIR       ${EDGE_IMPULSE_BINARY_DIR}
+    STAMP_DIR        ${EDGE_IMPULSE_STAMP_DIR}
+    DOWNLOAD_NAME    edge_impulse_src.zip
+    BUILD_BYPRODUCTS ${EDGE_IMPULSE_LIBRARY}
+    PATCH_COMMAND    ${CMAKE_COMMAND} -E copy
+                     ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.ei.template
+                     ${EDGE_IMPULSE_SOURCE_DIR}/CMakeLists.txt
+    CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_AR=${CMAKE_AR}
+               -DCMAKE_RANLIB=${CMAKE_RANLIB}
+               -DEI_COMPILE_DEFINITIONS=$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>
+               -DEI_INCLUDE_DIRECTORIES=$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>
+               -DEI_SYSTEM_INCLUDE_DIRECTORIES=$<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+               -DEI_LIBRARY_NAME=edge_impulse
+    INSTALL_COMMAND ""
+    BUILD_ALWAYS True
+    USES_TERMINAL_BUILD True
+)
+
+# This targets remove the `edge_impulse_project-download` stamp file, which
+# causes the Edge impulse library to be fetched on each build invocation.
+# Note: This also results in the `ALL` target to always be considered out-of-date.
+if(CONFIG_EDGE_IMPULSE_DOWNLOAD_ALWAYS)
+  add_custom_target(edge_impulse_project_download
+                    COMMAND ${CMAKE_COMMAND} -E rm -f
+                            ${EDGE_IMPULSE_STAMP_DIR}/edge_impulse_project-download
+                    DEPENDS edge_impulse_project
+  )
 endif()
 
-# Prepare Edge Impulse library zip archive
-if(CONFIG_EDGE_IMPULSE_BUILD_FROM_ZIP)
+zephyr_interface_library_named(edge_impulse)
+target_include_directories(edge_impulse INTERFACE
+                           ${EDGE_IMPULSE_SOURCE_DIR}
+                           ${EDGE_IMPULSE_SOURCE_DIR}/tflite-model
+                           ${EDGE_IMPULSE_SOURCE_DIR}/model-parameters
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/third_party/ruy
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/third_party/gemmlowp
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/third_party/flatbuffers/include
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/third_party
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/tensorflow
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/dsp
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/classifier
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/anomaly
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/CMSIS/NN/Include
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/CMSIS/DSP/PrivateInclude
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/CMSIS/DSP/Include
+                           ${EDGE_IMPULSE_SOURCE_DIR}/edge-impulse-sdk/CMSIS/Core/Include
+)
 
-  if(CONFIG_EDGE_IMPULSE_ZIP_PATH STREQUAL "")
-    message(FATAL_ERROR "CONFIG_EDGE_IMPULSE_ZIP_PATH must be specified in Kconfig.")
-  endif()
+target_link_libraries(edge_impulse INTERFACE ${EDGE_IMPULSE_LIBRARY})
 
-  set(EI_ZIP_PATH ${APPLICATION_SOURCE_DIR}/${CONFIG_EDGE_IMPULSE_ZIP_PATH})
-  if (NOT EXISTS ${EI_ZIP_PATH})
-    message(FATAL_ERROR "Specified Edge Impulse archive (${EI_ZIP_PATH}) does "
-             "not exist. Download the archive manually and place it under "
-             "defined path or use CONFIG_EDGE_IMPULSE_BUILD_FROM_URI Kconfig "
-             "option to let the build system download the library "
-             "automatically.")
-  else()
-    message(STATUS "Using Edge Impulse archive: ${EI_ZIP_PATH}.")
-  endif()
-
-elseif(CONFIG_EDGE_IMPULSE_BUILD_FROM_URI)
-
-  if(CONFIG_EDGE_IMPULSE_DOWNLOAD_URI STREQUAL "")
-    message(FATAL_ERROR "CONFIG_EDGE_IMPULSE_DOWNLOAD_URI must be specified in Kconfig.")
-  endif()
-
-  set(EI_ZIP_PATH ${EI_BASE_DIR}/src.zip)
-  set(EI_URI_DUMP ${EI_BASE_DIR}/uri.txt)
-
-  if(EXISTS ${EI_URI_DUMP})
-    file(READ ${EI_URI_DUMP} EI_URI)
-  else()
-    set(EI_URI " ")
-  endif()
-
-  if((NOT EXISTS ${EI_ZIP_PATH}) OR
-     (NOT CONFIG_EDGE_IMPULSE_DOWNLOAD_URI STREQUAL ${EI_URI}))
-    # Start download, use API key that was provided.
-    message(STATUS "Downloading Edge Impulse files, please wait...")
-
-    if(DEFINED EI_API_KEY_HEADER)
-      file(DOWNLOAD ${CONFIG_EDGE_IMPULSE_DOWNLOAD_URI} ${EI_ZIP_PATH}
-           SHOW_PROGRESS
-           STATUS download_status
-           HTTPHEADER "Accept: application/zip"
-           HTTPHEADER ${EI_API_KEY_HEADER})
-    else()
-      file(DOWNLOAD ${CONFIG_EDGE_IMPULSE_DOWNLOAD_URI} ${EI_ZIP_PATH}
-           SHOW_PROGRESS
-           STATUS download_status
-           HTTPHEADER "Accept: application/zip")
-    endif()
-
-    list(GET download_status 0 status_code)
-    if (status_code EQUAL 0)
-      message(STATUS "Successfully downloaded Edge Impulse archive.")
-      file(WRITE ${EI_URI_DUMP} ${CONFIG_EDGE_IMPULSE_DOWNLOAD_URI})
-    else()
-      file(REMOVE ${EI_ZIP_PATH})
-      file(REMOVE ${EI_URI_DUMP})
-      message(FATAL_ERROR "Failed to download Edge Impulse files. Please make "
-               "sure that CONFIG_EDGE_IMPULSE_DOWNLOAD_URI is properly defined "
-               "and EI_API_KEY_HEADER is specified (if needed).")
-    endif()
-  else()
-    message(STATUS "Edge Impulse zip archive is already downloaded.")
-  endif()
-
-else()
-  message(FATAL_ERROR "Unknown Edge Impulse build source.")
-endif()
-
-# Rerun CMake when zip file content changes
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${EI_ZIP_PATH})
-
-# Unzip Edge impulse source files
-file(REMOVE_RECURSE ${EI_UNZIPPED_DIR})
-file(MAKE_DIRECTORY ${EI_UNZIPPED_DIR})
-file(ARCHIVE_EXTRACT INPUT ${EI_ZIP_PATH} DESTINATION ${EI_UNZIPPED_DIR})
-
-add_subdirectory(${EI_UNZIPPED_DIR} ${EI_BINARY_DIR})
+add_dependencies(edge_impulse
+                 edge_impulse_project
+                 edge_impulse_project_download
+)

--- a/lib/edge_impulse/Kconfig
+++ b/lib/edge_impulse/Kconfig
@@ -17,41 +17,32 @@ menuconfig EDGE_IMPULSE
 
 if EDGE_IMPULSE
 
-choice
-	prompt "Select Edge Impulse library source"
-	default EDGE_IMPULSE_BUILD_FROM_ZIP
-
-config EDGE_IMPULSE_BUILD_FROM_ZIP
-	bool "Build Edge Impulse library from provided zip file"
+config APP_LINK_WITH_EDGE_IMPULSE
+	bool "Link 'app' with Edge Impulse"
+	default y
 	help
-	  Make sure to specify the zip path as EDGE_IMPULSE_ZIP_PATH Kconfig
-	  option.
+	  Add Edge Impulse header files to the 'app' include path. It may be
+	  disabled if the include paths for Edge Impulse are causing aliasing
+	  issues for 'app'.
 
-config EDGE_IMPULSE_BUILD_FROM_URI
-	bool "Download Edge Impulse library from URI and build it"
+config EDGE_IMPULSE_DOWNLOAD_ALWAYS
+	bool "Download Edge Impulse library on each build"
+	default y
 	help
-	  Make sure to specify the URI as EDGE_IMPULSE_DOWNLOAD_URI Kconfig
-	  option and provide API key header as EI_API_KEY_HEADER variable
-	  during build (if required by the HTTP server).
-
-endchoice
-
-config EDGE_IMPULSE_ZIP_PATH
-	string "Edge Impulse library zip path"
-	depends on EDGE_IMPULSE_BUILD_FROM_ZIP
-	default ''
-	help
-	  Specify path for zip file containing the Edge Impulse library.
-	  Path is relative to application source directory.
+	  Request the build system to download the Edge Impulse library on each
+	  build. This results in the build target to always be considered out
+	  of date.
+	  If the re-downloaded zip has no code changes, then no re-building of
+	  source is performed and only download of zip file will be done.
 
 config EDGE_IMPULSE_DOWNLOAD_URI
 	string "Edge Impulse library download URI"
-	depends on EDGE_IMPULSE_BUILD_FROM_URI
 	default ''
 	help
 	  Specify URI used to download archive with Edge Impulse library.
 	  The library will be downloaded into build directory. Make sure
 	  to specify the HTTP API key header as EI_API_KEY_HEADER variable
 	  during build if the HTTP server uses it.
+	  A local file can be specified as: file:///path/to/edge_impulse.zip.
 
 endif # EDGE_IMPULSE


### PR DESCRIPTION
Using ExternalProject for building the edge impulse library.

This allows downloading and extracting the zip file containing the model
on each build invocation.

In the event that sources are added or removed from the library the
ExternalProject ensures that the build system will correctly handle this
in the build system.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>